### PR TITLE
Fix {JSON_OBJECT}.hash_code implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+EIFGENs

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -161,7 +161,7 @@ feature -- Report
         do
             from
                 object.start
-                Result := object.item_for_iteration.hash_code
+                Result := object.out.hash_code
             until
                 object.off
             loop

--- a/test/autotest/test_suite/test_json_core.e
+++ b/test/autotest/test_suite/test_json_core.e
@@ -778,6 +778,17 @@ feature -- Test
 
         end
 
+    test_json_object_hash_code
+        local
+            ht: HASH_TABLE [ANY, JSON_VALUE]
+            jo: JSON_OBJECT
+        do
+            create ht.make (1)
+            create jo.make
+            ht.force ("", jo)
+            assert ("ht.has_key (jo)", ht.has_key (jo))
+        end
+
     test_json_failed_json_conversion
             -- Test converting an Eiffel object to JSON that is based on a class
             -- for which no JSON converter has been registered.


### PR DESCRIPTION
Don't call {HASH_TABLE}.item_for_iteration when {HASH_TABLE}.off
Use {HASH_TABLE}.out instead

Without this patch, there is a precondition violation when the JSON_OBJECT is empty (as demonstrated in the attached test case)
