### PR TITLE
Simplify the json object by adding type specific put and replace

### DIFF
--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -101,6 +101,18 @@ feature -- Change Element
             put (l_value, key)
         end
 
+    put_boolean (value: BOOLEAN; key: JSON_STRING)
+            -- Assuming there is no item of key `key',
+            -- insert `value' with `key'.
+        require
+            key_not_present: not has_key (key)
+        local
+            l_value: JSON_BOOLEAN
+        do
+            create l_value.make_boolean (value)
+            put (l_value, key)
+        end
+
     replace (value: detachable JSON_VALUE; key: JSON_STRING)
             -- Assuming there is no item of key `key',
             -- insert `value' with `key'.
@@ -151,6 +163,16 @@ feature -- Change Element
             l_value: JSON_NUMBER
         do
             create l_value.make_real (value)
+            replace (l_value, key)
+        end
+
+    replace_with_boolean (value: BOOLEAN; key: JSON_STRING)
+            -- Assuming there is no item of key `key',
+            -- insert `value' with `key'.
+        local
+            l_value: JSON_BOOLEAN
+        do
+            create l_value.make_boolean (value)
             replace (l_value, key)
         end
 


### PR DESCRIPTION
While creating objects of the type JSON_OBJECT, I was forced to write redundant code. This could be avoided by creating  a put/replace procedure for each data type (STRING, INTEGER, NATURAL and REAL).

```
        modal.put (create {JSON_STRING}.make_json("start_modal"), "type")
        modal.put (create {JSON_STRING}.make_json(url), "url")
        modal.put (create {JSON_STRING}.make_json(title), "title")
```

This code could be replaced with

```
        modal.put_string ("start_modal") "type")
        modal.put_string (url, "url")
        modal.put_string (title, "title")
```

Which is much easier to read. 
