### PR TITLE
API and library improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 EIFGENs
+*.rc
+*.log

--- a/library/extras/file/json_file_reader.e
+++ b/library/extras/file/json_file_reader.e
@@ -9,6 +9,7 @@ class
 feature -- Access
 
 	read_json_from (a_path: STRING): detachable STRING
+			-- Read JSON file at `a_path'.
 		local
 			l_file: PLAIN_TEXT_FILE
 			template_content: STRING

--- a/library/extras/visitor/json_pretty_string_visitor.e
+++ b/library/extras/visitor/json_pretty_string_visitor.e
@@ -12,7 +12,7 @@ inherit
 create
 	make, make_custom
 
-feature -- Initialization
+feature {NONE} -- Initialization
 
 	make (a_output: like output)
 			-- Create a new instance

--- a/library/extras/visitor/json_pretty_string_visitor.e
+++ b/library/extras/visitor/json_pretty_string_visitor.e
@@ -15,13 +15,13 @@ create
 feature {NONE} -- Initialization
 
 	make (a_output: like output)
-			-- Create a new instance
+			-- Create a new instance.
 		do
 			make_custom (a_output, 1, 1)
 		end
 
 	make_custom (a_output: like output; a_object_count_inlining, a_array_count_inlining: INTEGER)
-			-- Create a new instance
+			-- Create a new instance.
 		do
 			output := a_output
 			create indentation.make_empty
@@ -33,7 +33,7 @@ feature {NONE} -- Initialization
 feature -- Access
 
 	output: STRING_32
-			-- JSON representation
+			-- JSON representation.
 
 	indentation: like output
 

--- a/library/extras/visitor/print_json_visitor.e
+++ b/library/extras/visitor/print_json_visitor.e
@@ -17,7 +17,7 @@ create
 feature {NONE} -- Initialization
 
 	make
-			-- Create a new instance
+			-- Create a new instance.
 		do
 			create to_json.make_empty
 		end
@@ -25,7 +25,7 @@ feature {NONE} -- Initialization
 feature -- Access
 
 	to_json: STRING
-			-- JSON representation
+			-- JSON representation.
 
 feature -- Visitor Pattern
 

--- a/library/extras/visitor/print_json_visitor.e
+++ b/library/extras/visitor/print_json_visitor.e
@@ -15,7 +15,7 @@ inherit
 		end
 
 create
-	default_create
+	default_create, make
 
 feature {NONE} -- Initialization
 
@@ -23,6 +23,14 @@ feature {NONE} -- Initialization
 			-- Create a new instance.
 		do
 			create to_json.make_empty
+		end
+
+	make
+			-- Create a new instance.
+		obsolete
+			"Use `default_create' instead. 2014/07"
+		do
+			default_create
 		end
 
 feature -- Access

--- a/library/extras/visitor/print_json_visitor.e
+++ b/library/extras/visitor/print_json_visitor.e
@@ -14,7 +14,7 @@ inherit
 create
 	make
 
-feature -- Initialization
+feature {NONE} -- Initialization
 
 	make
 			-- Create a new instance

--- a/library/extras/visitor/print_json_visitor.e
+++ b/library/extras/visitor/print_json_visitor.e
@@ -10,13 +10,16 @@ class
 inherit
 
 	JSON_VISITOR
+		redefine
+			default_create
+		end
 
 create
-	make
+	default_create
 
 feature {NONE} -- Initialization
 
-	make
+	default_create
 			-- Create a new instance.
 		do
 			create to_json.make_empty

--- a/library/gobo/converters/json_ds_hash_table_converter.e
+++ b/library/gobo/converters/json_ds_hash_table_converter.e
@@ -26,9 +26,9 @@ feature -- Conversion
             until
                 i > keys.count
             loop
-                h ?= json.object (keys [i], void)
+                h ?= json.instance (keys [i], void)
                 check h /= Void end
-                a := json.object (j.item (keys [i]), Void)
+                a := json.instance (j.item (keys [i]), Void)
                 Result.put (a, h)
                 i := i + 1
             end

--- a/library/gobo/converters/json_ds_hash_table_converter.e
+++ b/library/gobo/converters/json_ds_hash_table_converter.e
@@ -10,25 +10,9 @@ class JSON_DS_HASH_TABLE_CONVERTER
 inherit
     JSON_CONVERTER
 
-create
-    make
-
-feature {NONE} -- Initialization
-
-    make
-        do
-            create object.make (0)
-        end
-
-feature -- Access
-
-    value: JSON_OBJECT
-
-    object: DS_HASH_TABLE [ANY, HASHABLE]
-
 feature -- Conversion
 
-    from_json (j: like value): detachable like object
+    from_json (j: like to_json): detachable DS_HASH_TABLE [ANY, HASHABLE]
         local
             keys: ARRAY [JSON_STRING]
             i: INTEGER
@@ -50,14 +34,14 @@ feature -- Conversion
             end
         end
 
-    to_json (o: like object): like value
+    to_json (o: attached like from_json): JSON_OBJECT
         local
             c: DS_HASH_TABLE_CURSOR [ANY, HASHABLE]
             js: JSON_STRING
             jv: JSON_VALUE
             failed: BOOLEAN
         do
-            create Result.make
+            create Result
             from
                 c := o.new_cursor
                 c.start

--- a/library/gobo/converters/json_ds_linked_list_converter.e
+++ b/library/gobo/converters/json_ds_linked_list_converter.e
@@ -22,7 +22,7 @@ feature -- Conversion
             until
                 i > j.count
             loop
-                Result.put_last (json.object (j [i], Void))
+                Result.put_last (json.instance (j [i], Void))
                 i := i + 1
             end
         end

--- a/library/gobo/converters/json_ds_linked_list_converter.e
+++ b/library/gobo/converters/json_ds_linked_list_converter.e
@@ -10,25 +10,9 @@ class JSON_DS_LINKED_LIST_CONVERTER
 inherit
     JSON_CONVERTER
 
-create
-    make
-
-feature {NONE} -- Initialization
-
-    make
-        do
-            create object.make
-        end
-
-feature -- Access
-
-    value: JSON_ARRAY
-
-    object: DS_LINKED_LIST [ANY]
-
 feature -- Conversion
 
-    from_json (j: like value): detachable like object
+    from_json (j: like to_json): DS_LINKED_LIST [detachable ANY]
         local
             i: INTEGER
         do
@@ -43,18 +27,18 @@ feature -- Conversion
             end
         end
 
-    to_json (o: like object): like value
+    to_json (o: like from_json): JSON_ARRAY
         local
             c: DS_LIST_CURSOR [ANY]
         do
-            create Result.make_array
+            create Result
             from
                 c := o.new_cursor
                 c.start
             until
                 c.after
             loop
-                Result.add (json.value (c.item))
+                Result.extend (json.value (c.item))
                 c.forth
             end
         end

--- a/library/gobo/shared_gobo_ejson.e
+++ b/library/gobo/shared_gobo_ejson.e
@@ -16,17 +16,17 @@ class SHARED_GOBO_EJSON
 feature
 
     json: EJSON
-            -- A shared EJSON instance with default converters for 
+            -- A shared EJSON instance with default converters for
 	    -- DS_LINKED_LIST [ANY] and DS_HASH_TABLE [ANY, HASHABLE]
         local
             jllc: JSON_DS_LINKED_LIST_CONVERTER
             jhtc: JSON_DS_HASH_TABLE_CONVERTER
         once
             create Result
-            create jllc.make
+            create jllc
             Result.add_converter (jllc)
-            create jhtc.make
+            create jhtc
             Result.add_converter (jhtc)
         end
-        
+
 end -- class SHARED_GOBO_EJSON

--- a/library/kernel/converters/json_array_converter.e
+++ b/library/kernel/converters/json_array_converter.e
@@ -1,0 +1,48 @@
+note
+	description: "Json converter for {ARRAY}."
+	author: ""
+	date: "$Date$"
+	revision: "$Revision$"
+
+class
+	JSON_ARRAY_CONVERTER
+
+inherit
+
+	JSON_CONVERTER
+
+feature -- Conversion
+
+	from_json (j: attached like to_json): ARRAY [detachable ANY]
+			-- <Precursor>
+		local
+			l_area: SPECIAL [detachable ANY]
+		do
+			create l_area.make_empty (j.count)
+			across
+				j as it
+			loop
+				l_area.extend (it.item)
+			end
+			create Result.make_from_special (l_area)
+		end
+
+	to_json (o: like from_json): detachable JSON_ARRAY
+			-- <Precursor>
+		do
+			create Result
+			across
+				o as it
+			until
+				Result = Void
+			loop
+				if attached json.value (it.item) as l_value then
+					Result.extend (l_value)
+				else
+					Result := Void
+						-- Failed
+				end
+			end
+		end
+
+end

--- a/library/kernel/converters/json_arrayed_list_converter.e
+++ b/library/kernel/converters/json_arrayed_list_converter.e
@@ -11,20 +11,13 @@ class
 inherit
 
 	JSON_LIST_CONVERTER
-		redefine
-			object
-		end
 
 create
-	make
-
-feature -- Access
-
-	object: ARRAYED_LIST [detachable ANY]
+	default_create
 
 feature {NONE} -- Factory
 
-	new_object (nb: INTEGER): like object
+	new_object (nb: INTEGER): ARRAYED_LIST [detachable ANY]
 		do
 			create Result.make (nb)
 		end

--- a/library/kernel/converters/json_arrayed_list_converter.e
+++ b/library/kernel/converters/json_arrayed_list_converter.e
@@ -15,7 +15,7 @@ inherit
 create
 	default_create
 
-feature {NONE} -- Factory
+feature -- Factory
 
 	new_object (nb: INTEGER): ARRAYED_LIST [detachable ANY]
 		do

--- a/library/kernel/converters/json_arrayed_list_converter.e
+++ b/library/kernel/converters/json_arrayed_list_converter.e
@@ -18,6 +18,7 @@ create
 feature -- Factory
 
 	new_object (nb: INTEGER): ARRAYED_LIST [detachable ANY]
+			-- <Precursor>
 		do
 			create Result.make (nb)
 		end

--- a/library/kernel/converters/json_converter.e
+++ b/library/kernel/converters/json_converter.e
@@ -1,5 +1,5 @@
 note
-	description: "A JSON converter"
+	description: "Ancestor for all JSON converters."
 	author: "Paul Cohen"
 	date: "$Date$"
 	revision: "$Revision$"
@@ -11,28 +11,40 @@ deferred class
 inherit
 
 	SHARED_EJSON
+		redefine
+			default_create
+		end
+
+feature {NONE} -- Initialization
+
+	default_create
+			-- Create a converter for `type'.
+		do
+			type := {attached like from_json}
+		end
 
 feature -- Access
 
-	object: ANY
-			-- Eiffel object
-		deferred
-		end
+	type: TYPE [attached like from_json]
+			-- Eiffel type.
 
 feature -- Conversion
 
-	from_json (j: attached like to_json): detachable like object
+	from_json (j: attached like to_json): detachable ANY
 			-- Convert from JSON value.
 			-- Returns Void if unable to convert
-		deferred
-		end
+		require
+			j_attached: j /= Void
+		deferred end
 
-	to_json (o: like object): detachable JSON_VALUE
-			-- Convert to JSON value
-		deferred
-		end
+	to_json (o: attached like from_json): detachable JSON_VALUE
+			-- Convert to JSON value.
+		require
+			o_attached: o /= Void
+		deferred end
 
 invariant
-	has_eiffel_object: object /= Void -- An empty object must be created at creation time!
+	has_eiffel_type: type /= Void
+	attached_type: type.is_attached
 
 end

--- a/library/kernel/converters/json_hash_table_converter.e
+++ b/library/kernel/converters/json_hash_table_converter.e
@@ -17,25 +17,25 @@ create
 
 feature -- Conversion
 
-	from_json (j: attached like to_json): detachable HASH_TABLE [ANY, HASHABLE]
+	from_json (j: attached like to_json): detachable HASH_TABLE [detachable ANY, HASHABLE]
 			-- <Precursor>
 		do
 			create Result.make (j.count)
 			across
 				j as ic
+			until
+				Result = Void
 			loop
 				if attached json.object (ic.item, Void) as l_object then
 					if attached {HASHABLE} json.object (ic.key, Void) as h then
 						Result.put (l_object, h)
 					else
-						check
-							key_is_hashable: False
-						end
+						Result := Void
+							-- Failed
 					end
 				else
-					check
-						object_attached: False
-					end
+					Result := Void
+						-- Failed
 				end
 			end
 		end
@@ -43,30 +43,30 @@ feature -- Conversion
 	to_json (o: attached like from_json): detachable JSON_OBJECT
 			-- <Precursor>
 		local
-			c: HASH_TABLE_ITERATION_CURSOR [ANY, HASHABLE]
 			js: JSON_STRING
-			failed: BOOLEAN
 		do
 			create Result.make
-			from
-				c := o.new_cursor
+			across
+				o as it
 			until
-				c.after
+				Result = Void
 			loop
-				if attached {JSON_STRING} json.value (c.key) as l_key then
-					js := l_key
+				if attached json.value (it.key) as l_value then
+					if attached {JSON_STRING} l_value as l_key then
+						js := l_key
+					else
+						create js.make_json (l_value.representation)
+					end
+					if attached json.value (it.item) as jv then
+						Result.put (jv, js)
+					else
+						Result := Void
+							-- Failed
+					end
 				else
-					create js.make_json (c.key.out)
+					Result := Void
+						-- Failed
 				end
-				if attached json.value (c.item) as jv then
-					Result.put (jv, js)
-				else
-					failed := True
-				end
-				c.forth
-			end
-			if failed then
-				Result := Void
 			end
 		end
 

--- a/library/kernel/converters/json_hash_table_converter.e
+++ b/library/kernel/converters/json_hash_table_converter.e
@@ -26,8 +26,8 @@ feature -- Conversion
 			until
 				Result = Void
 			loop
-				if attached json.object (ic.item, Void) as l_object then
-					if attached {HASHABLE} json.object (ic.key, Void) as h then
+				if attached json.instance (ic.item, Void) as l_object then
+					if attached {HASHABLE} json.instance (ic.key, Void) as h then
 						Result.put (l_object, h)
 					else
 						Result := Void

--- a/library/kernel/converters/json_hash_table_converter.e
+++ b/library/kernel/converters/json_hash_table_converter.e
@@ -45,7 +45,7 @@ feature -- Conversion
 		local
 			js: JSON_STRING
 		do
-			create Result.make
+			create Result
 			across
 				o as it
 			until

--- a/library/kernel/converters/json_hash_table_converter.e
+++ b/library/kernel/converters/json_hash_table_converter.e
@@ -13,22 +13,12 @@ inherit
 	JSON_CONVERTER
 
 create
-	make
-
-feature {NONE} -- Initialization
-
-	make
-		do
-			create object.make (0)
-		end
-
-feature -- Access
-
-	object: HASH_TABLE [ANY, HASHABLE]
+	default_create
 
 feature -- Conversion
 
-	from_json (j: attached like to_json): like object
+	from_json (j: attached like to_json): detachable HASH_TABLE [ANY, HASHABLE]
+			-- <Precursor>
 		do
 			create Result.make (j.count)
 			across
@@ -50,7 +40,8 @@ feature -- Conversion
 			end
 		end
 
-	to_json (o: like object): detachable JSON_OBJECT
+	to_json (o: attached like from_json): detachable JSON_OBJECT
+			-- <Precursor>
 		local
 			c: HASH_TABLE_ITERATION_CURSOR [ANY, HASHABLE]
 			js: JSON_STRING

--- a/library/kernel/converters/json_linked_list_converter.e
+++ b/library/kernel/converters/json_linked_list_converter.e
@@ -11,20 +11,14 @@ class
 inherit
 
 	JSON_LIST_CONVERTER
-		redefine
-			object
-		end
 
 create
-	make
+	default_create
 
-feature -- Access
+feature -- Factory
 
-	object: LINKED_LIST [detachable ANY]
-
-feature {NONE} -- Factory
-
-	new_object (nb: INTEGER): like object
+	new_object (nb: INTEGER): LINKED_LIST [detachable ANY]
+			-- <Precursor>
 		do
 			create Result.make
 		end

--- a/library/kernel/converters/json_list_converter.e
+++ b/library/kernel/converters/json_list_converter.e
@@ -21,7 +21,7 @@ feature -- Conversion
 			across
 				j as ic
 			loop
-				Result.extend (json.object (ic.item, Void))
+				Result.extend (json.instance (ic.item, Void))
 			end
 		end
 

--- a/library/kernel/converters/json_list_converter.e
+++ b/library/kernel/converters/json_list_converter.e
@@ -28,7 +28,7 @@ feature -- Conversion
 	to_json (o: like new_object): detachable JSON_ARRAY
 			-- <Precursor>
 		do
-			create Result.make_array
+			create Result
             across
 				o as it
             until

--- a/library/kernel/converters/json_list_converter.e
+++ b/library/kernel/converters/json_list_converter.e
@@ -12,28 +12,10 @@ inherit
 
 	JSON_CONVERTER
 
-feature {NONE} -- Initialization
-
-	make
-		do
-			object := new_object (0)
-		end
-
-feature -- Access
-
-	object: LIST [detachable ANY]
-
-feature {NONE} -- Factory
-
-	new_object (nb: INTEGER): like object
-		deferred
-		ensure
-			Result /= Void
-		end
-
 feature -- Conversion
 
-	from_json (j: attached like to_json): detachable like object
+	from_json (j: attached like to_json): detachable like new_object
+			-- <Precursor>
 		local
 			i: INTEGER
 		do
@@ -48,7 +30,8 @@ feature -- Conversion
 			end
 		end
 
-	to_json (o: like object): detachable JSON_ARRAY
+	to_json (o: like new_object): detachable JSON_ARRAY
+			-- <Precursor>
 		local
 			c: ITERATION_CURSOR [detachable ANY]
 			jv: detachable JSON_VALUE
@@ -72,5 +55,11 @@ feature -- Conversion
 				Result := Void
 			end
 		end
+
+feature -- Factory
+
+	new_object (nb: INTEGER): LIST [detachable ANY]
+	        -- Freshly created list.
+		deferred end
 
 end -- class JSON_ARRAYED_LIST_CONVERTER

--- a/library/kernel/converters/json_list_converter.e
+++ b/library/kernel/converters/json_list_converter.e
@@ -16,44 +16,31 @@ feature -- Conversion
 
 	from_json (j: attached like to_json): detachable like new_object
 			-- <Precursor>
-		local
-			i: INTEGER
 		do
 			Result := new_object (j.count)
-			from
-				i := 1
-			until
-				i > j.count
+			across
+				j as it
 			loop
-				Result.extend (json.object (j [i], Void))
-				i := i + 1
+				Result.extend (json.object (it.item, Void))
 			end
 		end
 
 	to_json (o: like new_object): detachable JSON_ARRAY
 			-- <Precursor>
-		local
-			c: ITERATION_CURSOR [detachable ANY]
-			jv: detachable JSON_VALUE
-			failed: BOOLEAN
 		do
 			create Result.make_array
-			from
-				c := o.new_cursor
-			until
-				c.after
-			loop
-				jv := json.value (c.item)
-				if jv /= Void then
-					Result.add (jv)
-				else
-					failed := True
-				end
-				c.forth
-			end
-			if failed then
-				Result := Void
-			end
+            across
+				o as it
+            until
+                Result = Void
+            loop
+                if attached json.value (it.item) as l_value then
+					Result.extend (l_value)
+                else
+			        Result := Void
+			            -- Failed
+                end
+            end
 		end
 
 feature -- Factory

--- a/library/kernel/converters/json_list_converter.e
+++ b/library/kernel/converters/json_list_converter.e
@@ -19,9 +19,9 @@ feature -- Conversion
 		do
 			Result := new_object (j.count)
 			across
-				j as it
+				j as ic
 			loop
-				Result.extend (json.object (it.item, Void))
+				Result.extend (json.object (ic.item, Void))
 			end
 		end
 

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -15,6 +15,15 @@ inherit
 			default_create
 		end
 
+inherit {NONE}
+
+	REFLECTOR
+		export
+			{NONE} all
+		undefine
+			default_create
+		end
+
 create
 	default_create
 
@@ -157,7 +166,7 @@ feature -- Access
 		require
 			a_type_attached: a_type /= Void
 		do
-			if converters.has_key (base_class_of (a_type)) then
+			if converters.has_key (class_name_of_type (a_type.type_id)) then
 				Result := converters.found_item
 			end
 		end
@@ -211,7 +220,7 @@ feature -- Change
 		require
 			jc_not_void: jc /= Void
 		do
-			converters.force (jc, base_class_of (jc.type))
+			converters.force (jc, class_name_of_type (jc.type.type_id))
 		ensure
 			has_converter: converter_of (jc.type) /= Void
 		end
@@ -243,7 +252,7 @@ feature {NONE} -- Implementation (Exceptions)
 		require
 			a_type_attached: a_type /= Void
 		do
-			Result := exception_prefix + "Failed to convert JSON_VALUE to an Eiffel object: " + a_value.generator + " -> {" + base_class_of (a_type) + "}"
+			Result := exception_prefix + "Failed to convert JSON_VALUE to an Eiffel object: " + a_value.generator + " -> {" + class_name_of_type (a_type.type_id) + "}"
 		end
 
 	exception_failed_to_convert_to_json (a_object: detachable ANY): STRING
@@ -259,33 +268,5 @@ feature {NONE} -- Implementation (JSON parser)
 
 	json_parser: JSON_PARSER
 			-- JSON parser.
-
-feature {NONE} -- Implementation (Type Helper)
-
-	base_class_of (a_type: TYPE [detachable ANY]): IMMUTABLE_STRING_8
-			-- Base class name of `a_type'.
-		local
-			i: INTEGER_32
-		do
-			Result := a_type.name
-			if a_type.is_attached then
-				check
-					first_character_is_attachment_mark: Result [1] = '!'
-				end
-				Result := Result.tail (Result.count - 1)
-					-- Remove attachment mark.
-			end
-			check
-				first_character_is_alhpabetic: Result [1].is_alpha
-			end
-			i := Result.index_of (' ', 2)
-			if i /= 0 then
-				Result := Result.head (i - 1)
-					-- Remove extras (spaces and generics).
-			end
-		ensure
-			valid_base_class: Result [1].is_alpha and
-				across Result.tail (Result.count - 1) as it all it.item.is_alpha_numeric or it.item = '_' end
-		end
 
 end -- class EJSON

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -11,6 +11,21 @@ class
 inherit
 
 	EXCEPTIONS
+		redefine
+			default_create
+		end
+
+create
+	default_create
+
+feature {NONE} -- Initialization
+
+	default_create
+			-- Create with no converters.
+		do
+			create converters.make (10)
+			create json_parser
+		end
 
 feature -- Access
 
@@ -205,9 +220,6 @@ feature {NONE} -- Implementation
 
 	converters: HASH_TABLE [JSON_CONVERTER, IMMUTABLE_STRING_8]
 			-- Converters hashed by generator (base class)
-		once
-			create Result.make (10)
-		end
 
 	default_json_array_converter: JSON_CONVERTER
 			-- Default converter for JSON_ARRAY.
@@ -246,9 +258,7 @@ feature {NONE} -- Implementation (Exceptions)
 feature {NONE} -- Implementation (JSON parser)
 
 	json_parser: JSON_PARSER
-		once
-			create Result.make_parser ("")
-		end
+			-- JSON parser.
 
 feature {NONE} -- Implementation (Type Helper)
 

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -69,8 +69,7 @@ feature -- Access
 				create {JSON_STRING} Result.make_json (s8)
 			elseif attached {STRING_32} an_object as s32 then
 				create {JSON_STRING} Result.make_json_from_string_32 (s32)
-			end
-			if Result = Void then
+			else
 					-- Now check the converters
 				if an_object /= Void and then attached converter_for (an_object) as jc then
 					Result := jc.to_json (an_object)

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -71,20 +71,6 @@ feature -- Access
 				create {JSON_NUMBER} Result.make_real (r32)
 			elseif attached {REAL_64} an_object as r64 then
 				create {JSON_NUMBER} Result.make_real (r64)
-			elseif attached {ARRAY [detachable ANY]} an_object as a then
-				create ja
-				across
-					a as it
-				loop
-					if attached value (it.item) as l_value then
-						ja.extend (l_value)
-					else
-						check
-							value_attached: False
-						end
-					end
-				end
-				Result := ja
 			elseif attached {CHARACTER_8} an_object as c8 then
 				create {JSON_STRING} Result.make_json (c8.out)
 			elseif attached {CHARACTER_32} an_object as c32 then

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -95,7 +95,7 @@ feature -- Access
 				create {JSON_STRING} Result.make_json_from_string_32 (s32)
 			else
 					-- Now check the converters
-				if an_object /= Void and then attached converter_for (an_object) as jc then
+				if attached converter_for (an_object) as jc then
 					Result := jc.to_json (an_object)
 				else
 					raise (exception_failed_to_convert_to_json (an_object))

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -48,7 +48,7 @@ feature -- Access
 			elseif attached {REAL_64} an_object as r64 then
 				create {JSON_NUMBER} Result.make_real (r64)
 			elseif attached {ARRAY [detachable ANY]} an_object as a then
-				create ja.make_array
+				create ja
 				across
 					a as it
 				loop
@@ -83,11 +83,6 @@ feature -- Access
 			-- Eiffel object from JSON value. If `base_class' /= Void an eiffel
 			-- object based on `base_class' will be returned. Raises an "eJSON
 			-- exception" if unable to convert value.
-		local
-			i: INTEGER
-			ll: LINKED_LIST [detachable ANY]
-			t: HASH_TABLE [detachable ANY, STRING_GENERAL]
-			keys: ARRAY [JSON_STRING]
 		do
 			if a_value = Void then
 				Result := Void
@@ -172,7 +167,7 @@ feature -- Access
 		local
 			js_key, js_value: JSON_STRING
 		do
-			create Result.make
+			create Result
 			create js_key.make_json ("$ref")
 			create js_value.make_json (s)
 			Result.put (js_value, js_key)
@@ -186,7 +181,7 @@ feature -- Access
 		require
 			a_list_not_void: a_list /= Void
 		do
-			create Result.make_array
+			create Result
 			across
 				a_list as it
 			loop

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -20,7 +20,7 @@ inherit {NONE}
 	REFLECTOR
 		export
 			{NONE} all
-		undefine
+		redefine
 			default_create
 		end
 

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -150,7 +150,7 @@ feature -- Access
 					if attached converter_of (a_type) as l_converter then
 						Result := l_converter.from_json (a_value)
 					else
-						raise (exception_failed_to_convert_to_eiffel (a_value, base_class_of (a_type)))
+						raise (exception_failed_to_convert_to_eiffel (a_value, a_type))
 					end
 				end
 			end
@@ -250,22 +250,22 @@ feature {NONE} -- Implementation
 feature {NONE} -- Implementation (Exceptions)
 
 	exception_prefix: STRING = "eJSON exception: "
+			-- Prefix for all EJSON exception.
 
-	exception_failed_to_convert_to_eiffel (a_value: JSON_VALUE; base_class: detachable STRING): STRING
-			-- Exception message for failing to convert a JSON_VALUE to an instance of `a'.
+	exception_failed_to_convert_to_eiffel (a_value: JSON_VALUE; a_type: TYPE [detachable ANY]): STRING
+			-- Exception message for failing to convert a JSON_VALUE to an instance of `a_value'.
+		require
+			a_type_attached: a_type /= Void
 		do
-			Result := exception_prefix + "Failed to convert JSON_VALUE to an Eiffel object: " + a_value.generator
-			if base_class /= Void then
-				Result.append (" -> {" + base_class + "}")
-			end
+			Result := exception_prefix + "Failed to convert JSON_VALUE to an Eiffel object: " + a_value.generator + " -> {" + base_class_of (a_type) + "}"
 		end
 
-	exception_failed_to_convert_to_json (an_object: detachable ANY): STRING
-			-- Exception message for failing to convert `a' to a JSON_VALUE.
+	exception_failed_to_convert_to_json (a_object: detachable ANY): STRING
+			-- Exception message for failing to convert `a_object' to a JSON_VALUE.
 		do
 			Result := exception_prefix + "Failed to convert Eiffel object to a JSON_VALUE"
-			if an_object /= Void then
-				Result.append (" : {" + an_object.generator + "}")
+			if a_object /= Void then
+				Result.append (" : {" + a_object.generator + "}")
 			end
 		end
 

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -18,7 +18,6 @@ feature -- Access
 			-- JSON value from Eiffel object. Raises an "eJSON exception" if
 			-- unable to convert value.
 		local
-			i: INTEGER
 			ja: JSON_ARRAY
 		do
 				-- Try to convert from basic Eiffel types. Note that we check with
@@ -50,19 +49,16 @@ feature -- Access
 				create {JSON_NUMBER} Result.make_real (r64)
 			elseif attached {ARRAY [detachable ANY]} an_object as a then
 				create ja.make_array
-				from
-					i := a.lower
-				until
-					i > a.upper
+				across
+					a as it
 				loop
-					if attached value (a @ i) as v then
-						ja.add (v)
+					if attached value (it.item) as l_value then
+						ja.extend (l_value)
 					else
 						check
 							value_attached: False
 						end
 					end
-					i := i + 1
 				end
 				Result := ja
 			elseif attached {CHARACTER_8} an_object as c8 then
@@ -97,10 +93,8 @@ feature -- Access
 			if a_value = Void then
 				Result := Void
 			else
-				if base_class = Void then
-					if a_value = Void then
-						Result := Void
-					elseif attached {JSON_NULL} a_value then
+				if a_type = Void then
+					if attached {JSON_NULL} a_value then
 						Result := Void
 					elseif attached {JSON_BOOLEAN} a_value as jb then
 						Result := jb.item
@@ -185,24 +179,19 @@ feature -- Access
 			Result.put (js_value, js_key)
 		end
 
-	json_references (l: LIST [STRING]): JSON_ARRAY
+	json_references (a_list: LIST [STRING]): JSON_ARRAY
 			-- A JSON array of JSON (Dojo style) reference objects using the
-			-- strings in `l' as reference values. The caller is responsable
-			-- for ensuring the validity of all strings in `l' as json
+			-- strings in `a_list' as reference values. The caller is responsable
+			-- for ensuring the validity of all strings in `a_list' as json
 			-- references.
 		require
-			l_not_void: l /= Void
-		local
-			c: ITERATION_CURSOR [STRING]
+			a_list_not_void: a_list /= Void
 		do
 			create Result.make_array
-			from
-				c := l.new_cursor
-			until
-				c.after
+			across
+				a_list as it
 			loop
-				Result.add (json_reference (c.item))
-				c.forth
+				Result.extend (json_reference (it.item))
 			end
 		end
 

--- a/library/kernel/ejson.e
+++ b/library/kernel/ejson.e
@@ -121,30 +121,9 @@ feature -- Access
 					elseif attached {JSON_STRING} a_value as js then
 						create {STRING_32} Result.make_from_string (js.unescaped_string_32)
 					elseif attached {JSON_ARRAY} a_value as ja then
-						from
-							create ll.make
-							i := 1
-						until
-							i > ja.count
-						loop
-							ll.extend (object (ja [i], Void))
-							i := i + 1
-						end
-						Result := ll
+						Result := default_json_array_converter.from_json (ja)
 					elseif attached {JSON_OBJECT} a_value as jo then
-						keys := jo.current_keys
-						create t.make (keys.count)
-						from
-							i := keys.lower
-						until
-							i > keys.upper
-						loop
-							if attached {STRING_GENERAL} object (keys [i], Void) as s then
-								t.put (object (jo.item (keys [i]), Void), s)
-							end
-							i := i + 1
-						end
-						Result := t
+						Result := default_json_object_converter.from_json (jo)
 					end
 				else
 					if attached converter_of (a_type) as l_converter then
@@ -247,6 +226,18 @@ feature {NONE} -- Implementation
 			create Result.make (10)
 		end
 
+	default_json_array_converter: JSON_CONVERTER
+			-- Default converter for JSON_ARRAY.
+		once
+			create {JSON_LINKED_LIST_CONVERTER} Result
+		end
+
+	default_json_object_converter: JSON_CONVERTER
+			-- Default converter for JSON_OBJECT.
+		once
+			create {JSON_HASH_TABLE_CONVERTER} Result
+		end
+
 feature {NONE} -- Implementation (Exceptions)
 
 	exception_prefix: STRING = "eJSON exception: "
@@ -291,7 +282,6 @@ feature {NONE} -- Implementation (Type Helper)
 				Result := Result.tail (Result.count - 1)
 					-- Remove attachment mark.
 			end
-
 			check
 				first_character_is_alhpabetic: Result [1].is_alpha
 			end

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -17,18 +17,27 @@ class
 inherit
 
 	JSON_VALUE
+		redefine
+			default_create
+		end
 
 	ITERABLE [JSON_VALUE]
+		undefine
+			default_create
+		end
 
 	DEBUG_OUTPUT
+		undefine
+			default_create
+		end
 
 create
-	make_array
+	default_create
 
 feature {NONE} -- Initialization
 
-	make_array
-			-- Initialize JSON Array
+	default_create
+			-- Initialize JSON Array.
 		do
 			create values.make (10)
 		end

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -170,7 +170,7 @@ feature -- Status report
 feature {NONE} -- Implementation
 
 	values: ARRAYED_LIST [JSON_VALUE]
-			-- Value container
+			-- Value container.
 
 invariant
 	value_not_void: values /= Void

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -32,7 +32,7 @@ inherit
 		end
 
 create
-	default_create
+	default_create, make_array
 
 feature {NONE} -- Initialization
 
@@ -40,6 +40,14 @@ feature {NONE} -- Initialization
 			-- Initialize JSON Array.
 		do
 			create values.make (10)
+		end
+
+	make_array
+			-- Initialize JSON Array.
+		obsolete
+			"Use `default_create' instead. 2014/07"
+		do
+			default_create
 		end
 
 feature -- Access
@@ -126,6 +134,17 @@ feature -- Change Element
 			v_not_void: v /= Void
 		do
 			values.extend (v)
+		ensure
+			has_new_value: old values.count + 1 = values.count and values.has (v)
+		end
+
+	add (v: JSON_VALUE)
+		obsolete
+			"Use `extend' instead. 2014/07"
+		require
+			v_not_void: v /= Void
+		do
+			extend (v)
 		ensure
 			has_new_value: old values.count + 1 = values.count and values.has (v)
 		end

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -111,7 +111,7 @@ feature -- Change Element
 			has_new_value: old values.count + 1 = values.count and values.first = v
 		end
 
-	add, extend (v: JSON_VALUE)
+	extend (v: JSON_VALUE)
 		require
 			v_not_void: v /= Void
 		do

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -69,9 +69,9 @@ feature -- Access
 				Result.append_character (']')
 			else
 				across
-					Current as it
+					Current as ic
 				loop
-					Result.append (it.item.representation)
+					Result.append (ic.item.representation)
 					Result.append_character (',')
 				end
 				Result [Result.count] := ']'
@@ -172,9 +172,9 @@ feature -- Report
 		do
 			Result := 0
 			across
-				values as it
+				values as ic
 			loop
-				Result := ((Result \\ 8388593) |<< 8) + it.item.hash_code
+				Result := ((Result \\ 8388593) |<< 8) + ic.item.hash_code
 			end
 			Result := Result \\ values.count
 		end

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -44,22 +44,21 @@ feature -- Access
 		end
 
 	representation: STRING
-		local
-			i: INTEGER
+			-- <Precursor>
 		do
-			Result := "["
-			from
-				i := 1
-			until
-				i > count
-			loop
-				Result.append (i_th (i).representation)
-				i := i + 1
-				if i <= count then
+			create Result.make (count * 2 + 1)
+			Result.append_character ('[')
+			if is_empty then
+				Result.append_character (']')
+			else
+				across
+					Current as it
+				loop
+					Result.append (it.item.representation)
 					Result.append_character (',')
 				end
+				Result [Result.count] := ']'
 			end
-			Result.append_character (']')
 		end
 
 feature -- Visitor pattern
@@ -93,6 +92,12 @@ feature -- Status report
 			-- Is `i' a valid index?
 		do
 			Result := (1 <= i) and (i <= count)
+		end
+
+	is_empty: BOOLEAN
+			-- Has no items?
+		do
+			Result := values.is_empty
 		end
 
 feature -- Change Element
@@ -136,14 +141,11 @@ feature -- Report
 	hash_code: INTEGER
 			-- Hash code value
 		do
-			from
-				values.start
-				Result := values.item.hash_code
-			until
-				values.off
+			Result := 0
+			across
+				values as it
 			loop
-				Result := ((Result \\ 8388593) |<< 8) + values.item.hash_code
-				values.forth
+				Result := ((Result \\ 8388593) |<< 8) + it.item.hash_code
 			end
 			Result := Result \\ values.count
 		end

--- a/library/kernel/json_array.e
+++ b/library/kernel/json_array.e
@@ -45,7 +45,7 @@ feature {NONE} -- Initialization
 feature -- Access
 
 	i_th alias "[]" (i: INTEGER): JSON_VALUE
-			-- Item at `i'-th position
+			-- Item at `i'-th position.
 		require
 			is_valid_index: valid_index (i)
 		do
@@ -74,7 +74,7 @@ feature -- Visitor pattern
 
 	accept (a_visitor: JSON_VISITOR)
 			-- Accept `a_visitor'.
-			-- (Call `visit_json_array' procedure on `a_visitor'.)
+			-- (Call `visit_json_array' procedure on `a_visitor'.).
 		do
 			a_visitor.visit_json_array (Current)
 		end
@@ -82,7 +82,7 @@ feature -- Visitor pattern
 feature -- Access
 
 	new_cursor: ITERATION_CURSOR [JSON_VALUE]
-			-- Fresh cursor associated with current structure
+			-- Fresh cursor associated with current structure.
 		do
 			Result := values.new_cursor
 		end
@@ -121,6 +121,7 @@ feature -- Change Element
 		end
 
 	extend (v: JSON_VALUE)
+			-- Add `v'.
 		require
 			v_not_void: v /= Void
 		do
@@ -163,7 +164,7 @@ feature -- Conversion
 
 	array_representation: ARRAYED_LIST [JSON_VALUE]
 			-- Representation as a sequences of values
-			-- be careful, modifying the return object may have impact on the original JSON_ARRAY object
+			-- be careful, modifying the return object may have impact on the original JSON_ARRAY object.
 		do
 			Result := values
 		end

--- a/library/kernel/json_boolean.e
+++ b/library/kernel/json_boolean.e
@@ -37,9 +37,9 @@ feature -- Access
 			-- <Precursor>
 		do
 			if item then
-				Result := "true"
+				Result := True_value
 			else
-				Result := "false"
+				Result := False_value
 			end
 		end
 
@@ -59,5 +59,13 @@ feature -- Status report
 		do
 			Result := item.out
 		end
+
+feature {NONE} -- Implementation
+
+	True_value: STRING_8 = "true"
+			-- JSON true value.
+
+	False_value: STRING_8 = "false"
+			-- JSON False value.
 
 end

--- a/library/kernel/json_boolean.e
+++ b/library/kernel/json_boolean.e
@@ -25,15 +25,16 @@ feature {NONE} -- Initialization
 feature -- Access
 
 	item: BOOLEAN
-			-- Content
+			-- Content.
 
 	hash_code: INTEGER
-			-- Hash code value
+			-- Hash code value.
 		do
 			Result := item.hash_code
 		end
 
 	representation: STRING
+			-- <Precursor>
 		do
 			if item then
 				Result := "true"

--- a/library/kernel/json_null.e
+++ b/library/kernel/json_null.e
@@ -14,21 +14,21 @@ inherit
 feature --Access
 
 	hash_code: INTEGER
-			-- Hash code value
+			-- Hash code value.
 		do
 			Result := null_value.hash_code
 		end
 
 	representation: STRING
 		do
-			Result := "null"
+			Result := Null_value
 		end
 
 feature -- Visitor pattern
 
 	accept (a_visitor: JSON_VISITOR)
 			-- Accept `a_visitor'.
-			-- (Call `visit_element_a' procedure on `a_visitor'.)
+			-- (Call `visit_element_a' procedure on `a_visitor'.).
 		do
 			a_visitor.visit_json_null (Current)
 		end
@@ -38,11 +38,12 @@ feature -- Status report
 	debug_output: STRING
 			-- String that should be displayed in debugger to represent `Current'.
 		do
-			Result := null_value
+			Result := Null_value
 		end
 
 feature {NONE} -- Implementation
 
-	null_value: STRING = "null"
+	Null_value: STRING = "null"
+			-- JSON null value.
 
 end

--- a/library/kernel/json_null.e
+++ b/library/kernel/json_null.e
@@ -20,6 +20,7 @@ feature --Access
 		end
 
 	representation: STRING
+			-- <Precursor>
 		do
 			Result := Null_value
 		end

--- a/library/kernel/json_number.e
+++ b/library/kernel/json_number.e
@@ -44,15 +44,16 @@ feature {NONE} -- initialization
 feature -- Access
 
 	item: STRING
-			-- Content
+			-- Content.
 
 	hash_code: INTEGER
-			--Hash code value
+			-- Hash code value.
 		do
 			Result := item.hash_code
 		end
 
 	representation: STRING
+			-- <Precursor>
 		do
 			Result := item
 		end
@@ -61,7 +62,7 @@ feature -- Visitor pattern
 
 	accept (a_visitor: JSON_VISITOR)
 			-- Accept `a_visitor'.
-			-- (Call `visit_json_number' procedure on `a_visitor'.)
+			-- (Call `visit_json_number' procedure on `a_visitor'.).
 		do
 			a_visitor.visit_json_number (Current)
 		end

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -35,14 +35,22 @@ inherit
 		end
 
 create
-	default_create
+	default_create, make
 
 feature {NONE} -- Initialization
 
 	default_create
-			-- Initialize
+			-- Create an empty object.
 		do
 			create object.make (10)
+		end
+
+	make
+			-- Create an empty object.
+		obsolete
+			"Use `default_create' instead. 2014/07"
+		do
+			default_create
 		end
 
 feature -- Change Element

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -237,7 +237,7 @@ feature -- Access
 feature -- Mesurement
 
 	count: INTEGER
-			-- Number of field
+			-- Number of field.
 		do
 			Result := object.count
 		end
@@ -245,7 +245,7 @@ feature -- Mesurement
 feature -- Access
 
 	new_cursor: TABLE_ITERATION_CURSOR [JSON_VALUE, JSON_STRING]
-			-- Fresh cursor associated with current structure
+			-- Fresh cursor associated with current structure.
 		do
 			Result := object.new_cursor
 		end
@@ -301,7 +301,7 @@ feature -- Status report
 feature {NONE} -- Implementation
 
 	object: HASH_TABLE [JSON_VALUE, JSON_STRING]
-			-- Value container
+			-- Value container.
 
 invariant
 	object_not_void: object /= Void

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -242,11 +242,11 @@ feature -- Access
 				Result.append_character ('}')
 			else
 				across
-					map_representation as it
+					map_representation as ic
 				loop
-					Result.append (it.key.representation)
+					Result.append (ic.key.representation)
 					Result.append_character (':')
-					Result.append (it.item.representation)
+					Result.append (ic.item.representation)
 					Result.append_character (',')
 				end
 				Result [Result.count] := '}'
@@ -301,9 +301,9 @@ feature -- Report
 		do
 			Result := 0
 			across
-				Current as it
+				Current as ic
 			loop
-				Result := ((Result \\ 8388593) |<< 8) + it.item.hash_code
+				Result := ((Result \\ 8388593) |<< 8) + ic.item.hash_code
 			end
 				-- Ensure it is a positive value.
 			Result := Result.hash_code

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -20,17 +20,26 @@ class
 inherit
 
 	JSON_VALUE
+		redefine
+			default_create
+		end
 
 	TABLE_ITERABLE [JSON_VALUE, JSON_STRING]
+		undefine
+			default_create
+		end
 
 	DEBUG_OUTPUT
+		undefine
+			default_create
+		end
 
 create
-	make
+	default_create
 
 feature {NONE} -- Initialization
 
-	make
+	default_create
 			-- Initialize
 		do
 			create object.make (10)

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -120,7 +120,7 @@ feature -- Change Element
 		local
 			l_value: JSON_VALUE
 		do
-			if l_value /= Void then
+			if value /= Void then
 				l_value := value
 			else
 				create {JSON_NULL} l_value

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -25,12 +25,12 @@ inherit
 		end
 
 	TABLE_ITERABLE [JSON_VALUE, JSON_STRING]
-		undefine
+		redefine
 			default_create
 		end
 
 	DEBUG_OUTPUT
-		undefine
+		redefine
 			default_create
 		end
 

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -220,7 +220,7 @@ feature -- Access
 		end
 
 	current_keys: ARRAY [JSON_STRING]
-			-- array containing actually used keys
+			-- array containing actually used keys.
 		do
 			Result := object.current_keys
 		end

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -215,26 +215,23 @@ feature -- Access
 		end
 
 	representation: STRING
-		local
-			t: HASH_TABLE [JSON_VALUE, JSON_STRING]
+			-- <Precursor>
 		do
-			create Result.make (2)
+			create Result.make (count * 2 + 1)
 			Result.append_character ('{')
-			from
-				t := map_representation
-				t.start
-			until
-				t.after
-			loop
-				Result.append (t.key_for_iteration.representation)
-				Result.append_character (':')
-				Result.append (t.item_for_iteration.representation)
-				t.forth
-				if not t.after then
+			if is_empty then
+				Result.append_character ('}')
+			else
+				across
+					map_representation as it
+				loop
+					Result.append (it.key.representation)
+					Result.append_character (':')
+					Result.append (it.item.representation)
 					Result.append_character (',')
 				end
+				Result [Result.count] := '}'
 			end
-			Result.append_character ('}')
 		end
 
 feature -- Mesurement
@@ -283,14 +280,11 @@ feature -- Report
 	hash_code: INTEGER
 			-- Hash code value
 		do
-			from
-				object.start
-				Result := object.out.hash_code
-			until
-				object.off
+			Result := 0
+			across
+				Current as it
 			loop
-				Result := ((Result \\ 8388593) |<< 8) + object.item_for_iteration.hash_code
-				object.forth
+				Result := ((Result \\ 8388593) |<< 8) + it.item.hash_code
 			end
 				-- Ensure it is a positive value.
 			Result := Result.hash_code

--- a/library/kernel/json_object.e
+++ b/library/kernel/json_object.e
@@ -44,10 +44,11 @@ feature -- Change Element
 		require
 			key_not_present: not has_key (key)
 		local
-			l_value: like value
+			l_value: JSON_VALUE
 		do
-			l_value := value
-			if l_value = Void then
+			if value /= Void then
+				l_value := value
+			else
 				create {JSON_NULL} l_value
 			end
 			object.extend (l_value, key)
@@ -117,10 +118,11 @@ feature -- Change Element
 			-- Assuming there is no item of key `key',
 			-- insert `value' with `key'.
 		local
-			l_value: like value
+			l_value: JSON_VALUE
 		do
-			l_value := value
-			if l_value = Void then
+			if l_value /= Void then
+				l_value := value
+			else
 				create {JSON_NULL} l_value
 			end
 			object.force (l_value, key)

--- a/library/kernel/json_string.e
+++ b/library/kernel/json_string.e
@@ -62,11 +62,8 @@ feature -- Conversion
 	unescaped_string_8: STRING_8
 			-- Unescaped string from `item'.
 			--| note: valid only if `item' does not encode any unicode character.
-		local
-			s: like item
 		do
-			s := item
-			create Result.make (s.count)
+			create Result.make (item.count)
 			unescape_to_string_8 (Result)
 		end
 
@@ -74,11 +71,8 @@ feature -- Conversion
 			-- Unescaped string 32 from `item'
 			--| some encoders uses UTF-8 , and not the recommended pure json encoding
 			--| thus, let's support the UTF-8 encoding during decoding.
-		local
-			s: READABLE_STRING_8
 		do
-			s := item
-			create Result.make (s.count)
+			create Result.make (item.count)
 			unescape_to_string_32 (Result)
 		end
 

--- a/library/kernel/json_string.e
+++ b/library/kernel/json_string.e
@@ -55,7 +55,7 @@ feature {NONE} -- Initialization
 feature -- Access
 
 	item: STRING
-			-- Contents with escaped entities if any
+			-- Contents with escaped entities if any.
 
 feature -- Conversion
 
@@ -83,7 +83,7 @@ feature -- Conversion
 		end
 
 	representation: STRING
-			-- String representation of `item' with escaped entities if any
+			-- String representation of `item' with escaped entities if any.
 		do
 			create Result.make (item.count + 2)
 			Result.append_character ('%"')
@@ -243,7 +243,7 @@ feature -- Visitor pattern
 
 	accept (a_visitor: JSON_VISITOR)
 			-- Accept `a_visitor'.
-			-- (Call `visit_json_string' procedure on `a_visitor'.)
+			-- (Call `visit_json_string' procedure on `a_visitor'.).
 		do
 			a_visitor.visit_json_string (Current)
 		end
@@ -260,7 +260,7 @@ feature -- Comparison
 feature -- Change Element
 
 	append (a_string: STRING)
-			-- Add a_string
+			-- Add a_string.
 		require
 			a_string_not_void: a_string /= Void
 		do
@@ -270,7 +270,7 @@ feature -- Change Element
 feature -- Status report
 
 	hash_code: INTEGER
-			-- Hash code value
+			-- Hash code value.
 		do
 			Result := item.hash_code
 		end
@@ -302,7 +302,7 @@ feature {NONE} -- Implementation
 		end
 
 	hexadecimal_to_natural_32 (s: READABLE_STRING_8): NATURAL_32
-			-- Hexadecimal string `s' converted to NATURAL_32 value
+			-- Hexadecimal string `s' converted to NATURAL_32 value.
 		require
 			s_not_void: s /= Void
 			is_hexadecimal: is_hexadecimal (s)
@@ -332,7 +332,7 @@ feature {NONE} -- Implementation
 		end
 
 	escaped_json_string (s: READABLE_STRING_8): STRING_8
-			-- JSON string with '"' and '\' characters escaped
+			-- JSON string with '"' and '\' characters escaped.
 		require
 			s_not_void: s /= Void
 		local
@@ -370,7 +370,7 @@ feature {NONE} -- Implementation
 		end
 
 	escaped_json_string_32 (s: READABLE_STRING_32): STRING_8
-			-- JSON string with '"' and '\' characters and Unicode escaped
+			-- JSON string with '"' and '\' characters and Unicode escaped.
 		require
 			s_not_void: s /= Void
 		local

--- a/library/kernel/json_string.e
+++ b/library/kernel/json_string.e
@@ -45,7 +45,7 @@ feature {NONE} -- Initialization
 		end
 
 	make_with_escaped_json (s: READABLE_STRING_8)
-			-- Initialize with an_item already escaped
+			-- Initialize with an_item already escaped.
 		require
 			item_not_void: s /= Void
 		do

--- a/library/kernel/json_value.e
+++ b/library/kernel/json_value.e
@@ -26,7 +26,7 @@ inherit
 feature -- Access
 
 	representation: STRING
-			-- UTF-8 encoded Unicode string representation of Current
+			-- UTF-8 encoded Unicode string representation of Current.
 		deferred
 		end
 

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -10,13 +10,25 @@ class
 inherit
 
 	JSON_READER
+		redefine
+			default_create
+		end
 
 	JSON_TOKENS
+		undefine
+			default_create
+		end
 
 create
-	make_parser
+	default_create, make_parser
 
 feature {NONE} -- Initialize
+
+	default_create
+			-- Create a default parser.
+		do
+			make_parser ("")
+		end
 
 	make_parser (a_json: STRING)
 			-- Initialize.

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -40,13 +40,10 @@ feature -- Status report
 			-- Current errors as string
 		do
 			create Result.make_empty
-			from
-				errors.start
-			until
-				errors.after
+			across
+				errors as it
 			loop
-				Result.append_string (errors.item + "%N")
-				errors.forth
+				Result.append_string (it.item + "%N")
 			end
 		end
 
@@ -491,13 +488,9 @@ feature {NONE} -- Implementation
 					Result := True
 					i := 3
 				until
-					i > 6 or Result = False
+					i > 6 or not Result
 				loop
-					inspect a_unicode [i]
-					when '0'..'9', 'a'..'f', 'A'..'F' then
-					else
-						Result := False
-					end
+					Result := a_unicode [i].is_alpha_numeric
 					i := i + 1
 				end
 			end

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -49,7 +49,7 @@ feature -- Status report
 			-- Current errors
 
 	current_errors: STRING
-			-- Current errors as string
+			-- Current errors as string.
 		do
 			create Result.make_empty
 			across
@@ -62,7 +62,7 @@ feature -- Status report
 feature -- Element change
 
 	report_error (e: STRING)
-			-- Report error `e'
+			-- Report error `e'.
 		require
 			e_not_void: e /= Void
 		do
@@ -73,7 +73,7 @@ feature -- Commands
 
 	parse_json: detachable JSON_VALUE
 			-- Parse JSON data `representation'
-			-- start ::= object | array
+			-- start ::= object | array.
 		do
 			if is_valid_start_symbol then
 				Result := parse
@@ -87,7 +87,7 @@ feature -- Commands
 		end
 
 	parse: detachable JSON_VALUE
-			-- Parse JSON data `representation'
+			-- Parse JSON data `representation'.
 		local
 			c: CHARACTER
 		do
@@ -188,7 +188,7 @@ feature -- Commands
 		end
 
 	parse_string: detachable JSON_STRING
-			-- Parsed string
+			-- Parsed string.
 		local
 			has_more: BOOLEAN
 			l_json_string: STRING
@@ -290,7 +290,7 @@ feature -- Commands
 		end
 
 	parse_number: detachable JSON_NUMBER
-			-- Parsed number
+			-- Parsed number.
 		local
 			sb: STRING
 			flag: BOOLEAN
@@ -366,7 +366,7 @@ feature -- Commands
 		end
 
 	read_unicode: STRING
-			-- Read Unicode and return value
+			-- Read Unicode and return value.
 		local
 			i: INTEGER
 		do
@@ -490,7 +490,7 @@ feature {NONE} -- Implementation
 		end
 
 	is_valid_unicode (a_unicode: STRING): BOOLEAN
-			-- is 'a_unicode' a valid Unicode based on this regular expression
+			-- is 'a_unicode' a valid Unicode based on this regular expression.
 			-- "\\u[0-9a-fA-F]{4}"
 		local
 			i: INTEGER
@@ -527,7 +527,7 @@ feature {NONE} -- Implementation
 		end
 
 	is_valid_start_symbol: BOOLEAN
-			-- expecting `{' or `[' as start symbol
+			-- expecting `{' or `[' as start symbol.
 		do
 			if attached representation as s and then s.count > 0 then
 				Result := s [1] = '{' or s [1] = '['

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -15,7 +15,7 @@ inherit
 		end
 
 	JSON_TOKENS
-		undefine
+		redefine
 			default_create
 		end
 

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -53,9 +53,9 @@ feature -- Status report
 		do
 			create Result.make_empty
 			across
-				errors as it
+				errors as ic
 			loop
-				Result.append_string (it.item + "%N")
+				Result.append_string (ic.item + "%N")
 			end
 		end
 

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -131,7 +131,7 @@ feature -- Commands
 			l_json_string: detachable JSON_STRING
 			l_value: detachable JSON_VALUE
 		do
-			create Result.make
+			create Result
 				-- check if is an empty object {}
 			next
 			skip_white_spaces
@@ -244,7 +244,7 @@ feature -- Commands
 			l_value: detachable JSON_VALUE
 			c: like actual
 		do
-			create Result.make_array
+			create Result
 				--check if is an empty array []
 			next
 			skip_white_spaces

--- a/library/kernel/scanner/json_parser.e
+++ b/library/kernel/scanner/json_parser.e
@@ -261,7 +261,7 @@ feature -- Commands
 					skip_white_spaces
 					l_value := parse
 					if is_parsed and then l_value /= Void then
-						Result.add (l_value)
+						Result.extend (l_value)
 						next
 						skip_white_spaces
 						c := actual

--- a/library/kernel/scanner/json_reader.e
+++ b/library/kernel/scanner/json_reader.e
@@ -13,7 +13,7 @@ create
 feature {NONE} -- Initialization
 
 	make (a_json: STRING)
-			-- Initialize Reader
+			-- Initialize Reader.
 		do
 			set_representation (a_json)
 		end
@@ -30,7 +30,7 @@ feature -- Commands
 		end
 
 	read: CHARACTER
-			-- Read character
+			-- Read character.
 		do
 			if not representation.is_empty then
 				Result := representation.item (index)
@@ -38,7 +38,7 @@ feature -- Commands
 		end
 
 	next
-			-- Move to next index
+			-- Move to next index.
 		require
 			has_more_elements: has_next
 		do
@@ -48,7 +48,7 @@ feature -- Commands
 		end
 
 	previous
-			-- Move to previous index
+			-- Move to previous index.
 		require
 			not_is_first: has_previous
 		do
@@ -58,7 +58,7 @@ feature -- Commands
 		end
 
 	skip_white_spaces
-			-- Remove white spaces
+			-- Remove white spaces.
 		local
 			c: like actual
 		do
@@ -73,7 +73,7 @@ feature -- Commands
 		end
 
 	json_substring (start_index, end_index: INTEGER_32): STRING
-			-- JSON representation between `start_index' and `end_index'
+			-- JSON representation between `start_index' and `end_index'.
 		do
 			Result := representation.substring (start_index, end_index)
 		end
@@ -95,12 +95,12 @@ feature -- Status report
 feature -- Access
 
 	representation: STRING
-			-- Serialized representation of the original JSON string
+			-- Serialized representation of the original JSON string.
 
 feature {NONE} -- Implementation
 
 	actual: CHARACTER
-			-- Current character or '%U' if none
+			-- Current character or '%U' if none.
 		do
 			if index > representation.count then
 				Result := '%U'
@@ -110,7 +110,7 @@ feature {NONE} -- Implementation
 		end
 
 	index: INTEGER
-			-- Actual index
+			-- Actual index.
 
 invariant
 	representation_not_void: representation /= Void

--- a/library/kernel/scanner/json_tokens.e
+++ b/library/kernel/scanner/json_tokens.e
@@ -36,7 +36,7 @@ feature -- Access
 feature -- Status report
 
 	is_open_token (c: CHARACTER): BOOLEAN
-			-- Characters which open a type
+			-- Characters which open a type.
 		do
 			inspect c
 			when j_OBJECT_OPEN, j_ARRAY_OPEN, j_STRING, j_PLUS, j_MINUS, j_DOT then
@@ -46,7 +46,7 @@ feature -- Status report
 		end
 
 	is_close_token (c: CHARACTER): BOOLEAN
-			-- Characters which close a type
+			-- Characters which close a type.
 		do
 			inspect c
 			when j_OBJECT_CLOSE, j_ARRAY_CLOSE, j_STRING then
@@ -74,7 +74,7 @@ feature -- Status report
 		end
 
 	is_special_control (c: CHARACTER): BOOLEAN
-			--Control Characters
+			-- Control Characters.
 			-- \b\f\n\r\t
 		do
 			inspect c

--- a/library/kernel/scanner/json_tokens.e
+++ b/library/kernel/scanner/json_tokens.e
@@ -10,20 +10,28 @@ class
 feature -- Access
 
 	j_OBJECT_OPEN: CHARACTER = '{'
+			-- Mark for object start.
 
 	j_ARRAY_OPEN: CHARACTER = '['
+			-- Mark for array start.
 
 	j_OBJECT_CLOSE: CHARACTER = '}'
+			-- Mark for object end.
 
 	j_ARRAY_CLOSE: CHARACTER = ']'
+			-- Mark for array end.
 
 	j_STRING: CHARACTER = '"'
+			-- Mark for string start and string end.
 
 	j_PLUS: CHARACTER = '+'
+			-- Mark for explicit positive number.
 
 	j_MINUS: CHARACTER = '-'
+			-- Mark for negative number.
 
 	j_DOT: CHARACTER = '.'
+			-- Mark for decimal number.
 
 feature -- Status report
 

--- a/library/kernel/shared_ejson.e
+++ b/library/kernel/shared_ejson.e
@@ -23,6 +23,7 @@ feature
 			jalc: JSON_ARRAYED_LIST_CONVERTER
 			jllc: JSON_LINKED_LIST_CONVERTER
 			jhtc: JSON_HASH_TABLE_CONVERTER
+			jac: JSON_ARRAY_CONVERTER
 		once
 			create Result
 			create jalc
@@ -31,6 +32,8 @@ feature
 			Result.add_converter (jllc)
 			create jhtc
 			Result.add_converter (jhtc)
+			create jac
+			Result.add_converter (jac)
 		end
 
 end -- class SHARED_EJSON

--- a/library/kernel/shared_ejson.e
+++ b/library/kernel/shared_ejson.e
@@ -18,7 +18,7 @@ feature
 
 	json: EJSON
 			-- A shared EJSON instance with default converters for
-			--LINKED_LIST [ANY] and HASH_TABLE [ANY, HASHABLE]
+			--LINKED_LIST [ANY] and HASH_TABLE [ANY, HASHABLE].
 		local
 			jalc: JSON_ARRAYED_LIST_CONVERTER
 			jllc: JSON_LINKED_LIST_CONVERTER

--- a/library/kernel/shared_ejson.e
+++ b/library/kernel/shared_ejson.e
@@ -25,11 +25,11 @@ feature
 			jhtc: JSON_HASH_TABLE_CONVERTER
 		once
 			create Result
-			create jalc.make
+			create jalc
 			Result.add_converter (jalc)
-			create jllc.make
+			create jllc
 			Result.add_converter (jllc)
-			create jhtc.make
+			create jhtc
 			Result.add_converter (jhtc)
 		end
 

--- a/test/autotest/test_suite/json_author_converter.e
+++ b/test/autotest/test_suite/json_author_converter.e
@@ -12,32 +12,20 @@ inherit
 	JSON_CONVERTER
 
 create
-	make
-
-feature {NONE} -- Initialization
-
-	make
-		local
-			ucs: STRING_32
-		do
-			create ucs.make_from_string ("")
-			create object.make (ucs)
-		end
-
-feature -- Access
-
-	object: AUTHOR
+	default_create
 
 feature -- Conversion
 
-	from_json (j: like to_json): detachable like object
+	from_json (j: like to_json): detachable AUTHOR
+			-- <Precursor>
 		do
 			if attached {STRING_32} json.object (j.item (name_key), Void) as l_name then
 				create Result.make (l_name)
 			end
 		end
 
-	to_json (o: like object): JSON_OBJECT
+	to_json (o: attached like from_json): JSON_OBJECT
+			-- <Precursor>
 		do
 			create Result.make
 			Result.put (json.value (o.name), name_key)

--- a/test/autotest/test_suite/json_author_converter.e
+++ b/test/autotest/test_suite/json_author_converter.e
@@ -27,7 +27,7 @@ feature -- Conversion
 	to_json (o: attached like from_json): JSON_OBJECT
 			-- <Precursor>
 		do
-			create Result.make
+			create Result
 			Result.put (json.value (o.name), name_key)
 		end
 

--- a/test/autotest/test_suite/json_author_converter.e
+++ b/test/autotest/test_suite/json_author_converter.e
@@ -19,7 +19,7 @@ feature -- Conversion
 	from_json (j: like to_json): detachable AUTHOR
 			-- <Precursor>
 		do
-			if attached {STRING_32} json.object (j.item (name_key), Void) as l_name then
+			if attached {STRING_32} json.instance (j.item (name_key), Void) as l_name then
 				create Result.make (l_name)
 			end
 		end

--- a/test/autotest/test_suite/json_book_collection_converter.e
+++ b/test/autotest/test_suite/json_book_collection_converter.e
@@ -22,7 +22,7 @@ feature -- Conversion
 			l_books: LINKED_LIST [BOOK]
 		do
 			if
-				attached {STRING_32} json.object (j.item (name_key), Void) as l_name and
+				attached {STRING_32} json.instance (j.item (name_key), Void) as l_name and
 				attached {JSON_ARRAY} j.item (books_key) as l_json_array
 			then
 				create Result.make (l_name)
@@ -32,7 +32,7 @@ feature -- Conversion
 				until
 					Result = Void
 				loop
-					if attached {BOOK} json.object (it.item, {BOOK}) as l_book then
+					if attached {BOOK} json.instance (it.item, {BOOK}) as l_book then
 						l_books.extend (l_book)
 					else
 						Result := Void

--- a/test/autotest/test_suite/json_book_collection_converter.e
+++ b/test/autotest/test_suite/json_book_collection_converter.e
@@ -45,7 +45,7 @@ feature -- Conversion
 				until
 					Result = Void
 				loop
-					if attached {BOOK} json.object (it.item, "BOOK") as l_book then
+					if attached {BOOK} json.object (it.item, {BOOK}) as l_book then
 						l_books.extend (l_book)
 					else
 						Result := Void

--- a/test/autotest/test_suite/json_book_collection_converter.e
+++ b/test/autotest/test_suite/json_book_collection_converter.e
@@ -48,7 +48,7 @@ feature -- Conversion
 	to_json (o: attached like from_json): JSON_OBJECT
 			-- <Precursor>
 		do
-			create Result.make
+			create Result
 			Result.put (json.value (o.name), name_key)
 			Result.put (json.value (o.books), books_key)
 		end

--- a/test/autotest/test_suite/json_book_collection_converter.e
+++ b/test/autotest/test_suite/json_book_collection_converter.e
@@ -12,25 +12,12 @@ inherit
 	JSON_CONVERTER
 
 create
-	make
-
-feature {NONE} -- Initialization
-
-	make
-		local
-			ucs: STRING_32
-		do
-			create ucs.make_from_string ("")
-			create object.make (ucs)
-		end
-
-feature -- Access
-
-	object: BOOK_COLLECTION
+	default_create
 
 feature -- Conversion
 
-	from_json (j: like to_json): detachable like object
+	from_json (j: like to_json): detachable BOOK_COLLECTION
+			-- <Precursor>
 		local
 			l_books: LINKED_LIST [BOOK]
 		do
@@ -58,7 +45,8 @@ feature -- Conversion
 			end
 		end
 
-	to_json (o: like object): JSON_OBJECT
+	to_json (o: attached like from_json): JSON_OBJECT
+			-- <Precursor>
 		do
 			create Result.make
 			Result.put (json.value (o.name), name_key)

--- a/test/autotest/test_suite/json_book_converter.e
+++ b/test/autotest/test_suite/json_book_converter.e
@@ -20,9 +20,9 @@ feature -- Conversion
 			-- <Precursor>
 		do
 			if
-				attached {STRING_32} json.object (j.item (title_key), Void) as l_title and
-				attached {STRING_32} json.object (j.item (isbn_key), Void) as l_isbn and
-				attached {AUTHOR} json.object (j.item (author_key), {AUTHOR}) as l_author
+				attached {STRING_32} json.instance (j.item (title_key), Void) as l_title and
+				attached {STRING_32} json.instance (j.item (isbn_key), Void) as l_isbn and
+				attached {AUTHOR} json.instance (j.item (author_key), {AUTHOR}) as l_author
 			then
 				create Result.make (l_title, l_author, l_isbn)
 			end

--- a/test/autotest/test_suite/json_book_converter.e
+++ b/test/autotest/test_suite/json_book_converter.e
@@ -31,7 +31,7 @@ feature -- Conversion
 	to_json (o: attached like from_json): JSON_OBJECT
 			-- <Precursor>
 		do
-			create Result.make
+			create Result
 			Result.put (json.value (o.title), title_key)
 			Result.put (json.value (o.isbn), isbn_key)
 			Result.put (json.value (o.author), author_key)

--- a/test/autotest/test_suite/json_book_converter.e
+++ b/test/autotest/test_suite/json_book_converter.e
@@ -37,7 +37,7 @@ feature -- Conversion
 			if
 				attached {STRING_32} json.object (j.item (title_key), Void) as l_title and
 				attached {STRING_32} json.object (j.item (isbn_key), Void) as l_isbn and
-				attached {AUTHOR} json.object (j.item (author_key), "AUTHOR") as l_author
+				attached {AUTHOR} json.object (j.item (author_key), {AUTHOR}) as l_author
 			then
 				create Result.make (l_title, l_author, l_isbn)
 			end

--- a/test/autotest/test_suite/json_book_converter.e
+++ b/test/autotest/test_suite/json_book_converter.e
@@ -12,27 +12,12 @@ inherit
 	JSON_CONVERTER
 
 create
-	make
-
-feature {NONE} -- Initialization
-
-	make
-		local
-			ucs: STRING_32
-			a: AUTHOR
-		do
-			create ucs.make_from_string ("")
-			create a.make (ucs)
-			create object.make (ucs, a, ucs)
-		end
-
-feature -- Access
-
-	object: BOOK
+	default_create
 
 feature -- Conversion
 
-	from_json (j: like to_json): detachable like object
+	from_json (j: like to_json): detachable BOOK
+			-- <Precursor>
 		do
 			if
 				attached {STRING_32} json.object (j.item (title_key), Void) as l_title and
@@ -43,7 +28,8 @@ feature -- Conversion
 			end
 		end
 
-	to_json (o: like object): JSON_OBJECT
+	to_json (o: attached like from_json): JSON_OBJECT
+			-- <Precursor>
 		do
 			create Result.make
 			Result.put (json.value (o.title), title_key)

--- a/test/autotest/test_suite/test_ds.e
+++ b/test/autotest/test_suite/test_ds.e
@@ -29,7 +29,7 @@ feature -- Test
 			l.force ("bar")
 			if attached json.value (l) as l_value then
 				s := l_value.representation
-				assert ("JSON array converted to LINKED_LIST", attached {LINKED_LIST [detachable ANY]} json.object (l_value, {LINKED_LIST [detachable ANY]}))
+				assert ("JSON array converted to LINKED_LIST", attached {LINKED_LIST [detachable ANY]} json.instance (l_value, {LINKED_LIST [detachable ANY]}))
 			else
 				assert ("LINKED_LIST converted to a JSON value", False)
 			end
@@ -48,7 +48,7 @@ feature -- Test
 			t.put ("bar", "2")
 			if attached json.value (t) as l_value then
 				s := l_value.representation
-				if attached {HASH_TABLE [detachable ANY, HASHABLE]} json.object (l_value, {HASH_TABLE [ANY, HASHABLE]}) as t2 then
+				if attached {HASH_TABLE [detachable ANY, HASHABLE]} json.instance (l_value, {HASH_TABLE [ANY, HASHABLE]}) as t2 then
 					create l_ucs_key.make_from_string ("1")
 					if attached {STRING_32} t2 [l_ucs_key] as l_ucs_value then
 						assert ("ucs_value.string.is_equal (%"foo%")", l_ucs_value.string.is_equal ("foo"))

--- a/test/autotest/test_suite/test_ds.e
+++ b/test/autotest/test_suite/test_ds.e
@@ -29,7 +29,7 @@ feature -- Test
 			l.force ("bar")
 			if attached json.value (l) as l_value then
 				s := l_value.representation
-				assert ("JSON array converted to LINKED_LIST", attached {LINKED_LIST [detachable ANY]} json.object (l_value, "LINKED_LIST"))
+				assert ("JSON array converted to LINKED_LIST", attached {LINKED_LIST [detachable ANY]} json.object (l_value, {LINKED_LIST [detachable ANY]}))
 			else
 				assert ("LINKED_LIST converted to a JSON value", False)
 			end
@@ -48,7 +48,7 @@ feature -- Test
 			t.put ("bar", "2")
 			if attached json.value (t) as l_value then
 				s := l_value.representation
-				if attached {HASH_TABLE [ANY, HASHABLE]} json.object (l_value, "HASH_TABLE") as t2 then
+				if attached {HASH_TABLE [ANY, HASHABLE]} json.object (l_value, {HASH_TABLE [ANY, HASHABLE]}) as t2 then
 					create l_ucs_key.make_from_string ("1")
 					if attached {STRING_32} t2 [l_ucs_key] as l_ucs_value then
 						assert ("ucs_value.string.is_equal (%"foo%")", l_ucs_value.string.is_equal ("foo"))

--- a/test/autotest/test_suite/test_ds.e
+++ b/test/autotest/test_suite/test_ds.e
@@ -48,7 +48,7 @@ feature -- Test
 			t.put ("bar", "2")
 			if attached json.value (t) as l_value then
 				s := l_value.representation
-				if attached {HASH_TABLE [ANY, HASHABLE]} json.object (l_value, {HASH_TABLE [ANY, HASHABLE]}) as t2 then
+				if attached {HASH_TABLE [detachable ANY, HASHABLE]} json.object (l_value, {HASH_TABLE [ANY, HASHABLE]}) as t2 then
 					create l_ucs_key.make_from_string ("1")
 					if attached {STRING_32} t2 [l_ucs_key] as l_ucs_value then
 						assert ("ucs_value.string.is_equal (%"foo%")", l_ucs_value.string.is_equal ("foo"))

--- a/test/autotest/test_suite/test_json_core.e
+++ b/test/autotest/test_suite/test_json_core.e
@@ -37,7 +37,7 @@ feature -- Test
 			jrep := "42"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_8} json.object (jn, Void) as l_i8 then
+				if attached {INTEGER_8} json.instance (jn, Void) as l_i8 then
 					assert ("l_i8 = 42", l_i8 = 42)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_8", False)
@@ -72,7 +72,7 @@ feature -- Test
 			jrep := "42"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_8} json.object (jn, Void) as l_i8 then
+				if attached {INTEGER_8} json.instance (jn, Void) as l_i8 then
 					assert ("l_i8 = 42", l_i8 = 42)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_8", False)
@@ -107,7 +107,7 @@ feature -- Test
 			jrep := "300"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_16} json.object (jn, Void) as l_i16 then
+				if attached {INTEGER_16} json.instance (jn, Void) as l_i16 then
 					assert ("l_i16 = 300", l_i16 = 300)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_16", False)
@@ -142,7 +142,7 @@ feature -- Test
 			jrep := "100000"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_32} json.object (jn, Void) as l_i32 then
+				if attached {INTEGER_32} json.instance (jn, Void) as l_i32 then
 					assert ("l_i32 = 100000", l_i32 = 100000)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_32", False)
@@ -177,7 +177,7 @@ feature -- Test
 			jrep := "42949672960"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_64} json.object (jn, Void) as l_i64 then
+				if attached {INTEGER_64} json.instance (jn, Void) as l_i64 then
 					assert ("l_i64 = 42949672960", l_i64 = 42949672960)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_64", False)
@@ -212,7 +212,7 @@ feature -- Test
 			jrep := "200"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_16} json.object (jn, Void) as i16 then
+				if attached {INTEGER_16} json.instance (jn, Void) as i16 then
 					assert ("i16 = 200", i16 = 200)
 				else
 					assert ("json.object (jn, Void) is an INTEGER_16", False)
@@ -247,7 +247,7 @@ feature -- Test
 			jrep := "32768"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_32} json.object (jn, Void) as i32 then
+				if attached {INTEGER_32} json.instance (jn, Void) as i32 then
 					assert ("i32 = 32768", i32 = 32768)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_32", False)
@@ -282,7 +282,7 @@ feature -- Test
 			jrep := "2147483648"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {INTEGER_64} json.object (jn, Void) as i64 then
+				if attached {INTEGER_64} json.instance (jn, Void) as i64 then
 					assert ("i64 = 2147483648", i64 = 2147483648)
 				else
 					assert ("json.object (jn, Void) is a INTEGER_64", False)
@@ -317,7 +317,7 @@ feature -- Test
 			jrep := "9223372036854775808" -- 1 higher than largest positive number that can be represented by INTEGER 64
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {NATURAL_64} json.object (jn, Void) as l_n64 then
+				if attached {NATURAL_64} json.instance (jn, Void) as l_n64 then
 					assert ("l_n64 = 9223372036854775808", l_n64 = 9223372036854775808)
 				else
 					assert ("json.object (jn, Void) is a NATURAL_64", False)
@@ -351,7 +351,7 @@ feature -- Test
 			jrep := "3.14"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {REAL_64} json.object (jn, Void) as r64 then
+				if attached {REAL_64} json.instance (jn, Void) as r64 then
 					assert ("3.14 <= r64 and r64 <= 3.141", 3.14 <= r64 and r64 <= 3.141)
 				else
 					assert ("json.object (jn, Void) is a REAL_64", False)
@@ -383,7 +383,7 @@ feature -- Test
 			jrep := "3.1400001049041748"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {REAL_64} json.object (l_jn, Void) as r64 then
+				if attached {REAL_64} json.instance (l_jn, Void) as r64 then
 					assert ("r64 = 3.1400001049041748", r64 = 3.1400001049041748)
 				else
 					assert ("json.object (l_jn, Void) is a REAL_64", False)
@@ -416,7 +416,7 @@ feature -- Test
 			jrep := "3.1415926535897931"
 			create parser.make_parser (jrep)
 			if attached {JSON_NUMBER} parser.parse as l_jn then
-				if attached {REAL_64} json.object (jn, Void) as l_r64 then
+				if attached {REAL_64} json.instance (jn, Void) as l_r64 then
 					assert ("l_r64 = 3.1415926535897931", l_r64 = 3.1415926535897931)
 				else
 					assert ("json.object (jn, Void) is a REAL_64", False)
@@ -446,7 +446,7 @@ feature -- Test
 				-- JSON representation -> JSON value -> Eiffel value
 			create parser.make_parser ("true")
 			if attached {JSON_BOOLEAN} parser.parse as l_jb then
-				if attached {BOOLEAN} json.object (l_jb, Void) as l_b then
+				if attached {BOOLEAN} json.instance (l_jb, Void) as l_b then
 					assert ("l_b = True", l_b = True)
 				else
 					assert ("json.object (l_jb, Void) is BOOLEAN", False)
@@ -469,7 +469,7 @@ feature -- Test
 				-- JSON representation -> JSON value -> Eiffel value
 			create parser.make_parser ("false")
 			if attached {JSON_BOOLEAN} parser.parse as l_jb then
-				if attached {BOOLEAN} json.object (l_jb, Void) as l_b then
+				if attached {BOOLEAN} json.instance (l_jb, Void) as l_b then
 					assert ("l_b = False", l_b = False)
 				else
 					assert ("json.object (l_jb, Void) is a BOOLEAN", False)
@@ -499,7 +499,7 @@ feature -- Test
 				-- JSON representation -> JSON value -> Eiffel value
 			create parser.make_parser (jrep)
 			if attached parser.parse as l_json_null then
-				assert ("a = Void", json.object (l_json_null, Void) = Void)
+				assert ("a = Void", json.instance (l_json_null, Void) = Void)
 			else
 				assert ("parser.parse /= Void", False)
 			end
@@ -527,7 +527,7 @@ feature -- Test
 			jrep := "%"a%""
 			create parser.make_parser (jrep)
 			if attached {JSON_STRING} parser.parse as l_json_str then
-				if attached {STRING_32} json.object (l_json_str, Void) as ucs then
+				if attached {STRING_32} json.instance (l_json_str, Void) as ucs then
 					assert ("ucs.string.is_equal (%"a%")", ucs.string.is_equal ("a"))
 				end
 			else
@@ -558,7 +558,7 @@ feature -- Test
 				-- JSON representation -> JSON value -> Eiffel value
 			create parser.make_parser (jrep)
 			if attached {JSON_STRING} parser.parse as l_js then
-				if attached {STRING_32} json.object (l_js, Void) as l_ucs then
+				if attached {STRING_32} json.instance (l_js, Void) as l_ucs then
 					assert ("ucs.string.is_equal (%"foobar%")", l_ucs.string.is_equal (s))
 				end
 			else
@@ -591,7 +591,7 @@ feature -- Test
 				-- JSON representation -> JSON value -> Eiffel value
 			create parser.make_parser (jrep)
 			if attached {JSON_STRING} parser.parse as l_js then
-				if attached {STRING_32} json.object (l_js, Void) as l_ucs then
+				if attached {STRING_32} json.instance (l_js, Void) as l_ucs then
 					assert ("ucs.string.is_equal (%"foobar%")", l_ucs.string.is_equal (s))
 				else
 					assert ("json.object (js, Void) /= Void", False)
@@ -623,7 +623,7 @@ feature -- Test
 				-- JSON representation -> JSON value -> Eiffel value
 			create parser.make_parser (jrep)
 			if attached {JSON_STRING} parser.parse as l_js then
-				if attached {STRING_32} json.object (l_js, Void) as l_ucs then
+				if attached {STRING_32} json.instance (l_js, Void) as l_ucs then
 					assert ("ucs.same_string (%"foo\bar%")", l_ucs.same_string ("foo\bar"))
 				end
 			else
@@ -692,7 +692,7 @@ feature -- Test
 			jrep := "[0,1,1,2,3,5]"
 			create parser.make_parser (jrep)
 			if attached {JSON_ARRAY} parser.parse as l_ja then
-				if attached {LINKED_LIST [detachable ANY]} json.object (ja, Void) as l_ll2 then
+				if attached {LINKED_LIST [detachable ANY]} json.instance (ja, Void) as l_ll2 then
 					assert ("ll2.is_equal (ll)", l_ll2.is_equal (ll))
 				else
 					assert ("json.object (ja, Void) /= Void", False)
@@ -765,7 +765,7 @@ feature -- Test
 			jrep := "{%"name%":%"foobar%",%"size%":42,%"contents%":[0,1,1,2,3,5]}"
 			create parser.make_parser (jrep)
 			if attached {JSON_OBJECT} parser.parse as l_jo then
-				if attached {HASH_TABLE [detachable ANY, HASHABLE]} json.object (l_jo, Void) as l_t2 then
+				if attached {HASH_TABLE [detachable ANY, HASHABLE]} json.instance (l_jo, Void) as l_t2 then
 					if attached json.value (l_t2) as l_jo_2 then
 						assert ("jrep.is_equal (jo.representation)", jrep.is_equal (l_jo_2.representation))
 					else
@@ -819,7 +819,7 @@ feature -- Test
 		do
 			if not exception then
 				create jo
-				gv := json.object (jo, {OPERATING_ENVIRONMENT})
+				gv := json.instance (jo, {OPERATING_ENVIRONMENT})
 			else
 				assert ("exceptions.is_developer_exception", json.is_developer_exception)
 			end

--- a/test/autotest/test_suite/test_json_core.e
+++ b/test/autotest/test_suite/test_json_core.e
@@ -665,7 +665,7 @@ feature -- Test
 			ll.extend (5)
 				-- Note: Currently there is no simple way of creating a JSON_ARRAY
 				-- from an LINKED_LIST.
-			create ja.make_array
+			create ja
 			from
 				ll.start
 			until
@@ -719,7 +719,7 @@ feature -- Test
 				-- Note: Currently there is now way of creating a JSON_OBJECT from
 				-- a HASH_TABLE, so we do it manually.
 				-- t = {"name": "foobar", "size": 42, "contents", [0, 1, 1, 2, 3, 5]}
-			create jo.make
+			create jo
 			create js_key.make_json ("name")
 			create js.make_json ("foobar")
 			jo.put (js, js_key)
@@ -727,7 +727,7 @@ feature -- Test
 			create jn.make_integer (42)
 			jo.put (jn, js_key)
 			create js_key.make_json ("contents")
-			create ja.make_array
+			create ja
 			create jn.make_integer (0)
 			ja.extend (jn)
 			create jn.make_integer (1)
@@ -785,7 +785,7 @@ feature -- Test
 			jo: JSON_OBJECT
 		do
 			create ht.make (1)
-			create jo.make
+			create jo
 			ht.force ("", jo)
 			assert ("ht.has_key (jo)", ht.has_key (jo))
 		end
@@ -818,7 +818,7 @@ feature -- Test
 			exception: BOOLEAN
 		do
 			if not exception then
-				create jo.make
+				create jo
 				gv := json.object (jo, {OPERATING_ENVIRONMENT})
 			else
 				assert ("exceptions.is_developer_exception", json.is_developer_exception)

--- a/test/autotest/test_suite/test_json_core.e
+++ b/test/autotest/test_suite/test_json_core.e
@@ -819,7 +819,7 @@ feature -- Test
 		do
 			if not exception then
 				create jo.make
-				gv := json.object (jo, "OPERATING_ENVIRONMENT")
+				gv := json.object (jo, {OPERATING_ENVIRONMENT})
 			else
 				assert ("exceptions.is_developer_exception", json.is_developer_exception)
 			end

--- a/test/autotest/test_suite/test_json_core.e
+++ b/test/autotest/test_suite/test_json_core.e
@@ -672,7 +672,7 @@ feature -- Test
 				ll.after
 			loop
 				create jn.make_integer (ll.item)
-				ja.add (jn)
+				ja.extend (jn)
 				ll.forth
 			end
 			assert ("ja /= Void", ja /= Void)
@@ -729,17 +729,17 @@ feature -- Test
 			create js_key.make_json ("contents")
 			create ja.make_array
 			create jn.make_integer (0)
-			ja.add (jn)
+			ja.extend (jn)
 			create jn.make_integer (1)
-			ja.add (jn)
+			ja.extend (jn)
 			create jn.make_integer (1)
-			ja.add (jn)
+			ja.extend (jn)
 			create jn.make_integer (2)
-			ja.add (jn)
+			ja.extend (jn)
 			create jn.make_integer (3)
-			ja.add (jn)
+			ja.extend (jn)
 			create jn.make_integer (5)
-			ja.add (jn)
+			ja.extend (jn)
 			jo.put (ja, js_key)
 			assert ("jo /= Void", jo /= Void)
 			assert ("jo.representation.is_equal (%"{%"name%":%"foobar%",%"size%":42,%"contents%":[0,1,1,2,3,5]}%")", jo.representation.is_equal ("{%"name%":%"foobar%",%"size%":42,%"contents%":[0,1,1,2,3,5]}"))

--- a/test/autotest/test_suite/test_json_core.e
+++ b/test/autotest/test_suite/test_json_core.e
@@ -765,7 +765,7 @@ feature -- Test
 			jrep := "{%"name%":%"foobar%",%"size%":42,%"contents%":[0,1,1,2,3,5]}"
 			create parser.make_parser (jrep)
 			if attached {JSON_OBJECT} parser.parse as l_jo then
-				if attached {HASH_TABLE [detachable ANY, STRING_GENERAL]} json.object (l_jo, Void) as l_t2 then
+				if attached {HASH_TABLE [detachable ANY, HASHABLE]} json.object (l_jo, Void) as l_t2 then
 					if attached json.value (l_t2) as l_jo_2 then
 						assert ("jrep.is_equal (jo.representation)", jrep.is_equal (l_jo_2.representation))
 					else

--- a/test/autotest/test_suite/test_json_custom_classes.e
+++ b/test/autotest/test_suite/test_json_custom_classes.e
@@ -35,7 +35,7 @@ feature -- Test
 			jrep := "{%"name%":%"Test collection%",%"books%":[{%"title%":%"eJSON: The Definitive Guide%",%"isbn%":%"123123-413243%",%"author%":{%"name%":%"Foo Bar%"}}]}"
 			create parser.make_parser (jrep)
 			if attached {JSON_OBJECT} parser.parse as l_json_object then
-				if attached {BOOK_COLLECTION} json.object (l_json_object, "BOOK_COLLECTION") as l_collection then
+				if attached {BOOK_COLLECTION} json.object (l_json_object, {BOOK_COLLECTION}) as l_collection then
 					if attached {JSON_OBJECT} json.value (l_collection) as l_json_object_2 then
 						assert ("JSON representation is correct", l_json_object_2.representation.same_string (jrep))
 					else

--- a/test/autotest/test_suite/test_json_custom_classes.e
+++ b/test/autotest/test_suite/test_json_custom_classes.e
@@ -26,11 +26,11 @@ feature -- Test
 			parser: JSON_PARSER
 			jrep: STRING
 		do
-			create jbc.make
+			create jbc
 			json.add_converter (jbc)
-			create jbcc.make
+			create jbcc
 			json.add_converter (jbcc)
-			create jac.make
+			create jac
 			json.add_converter (jac)
 			jrep := "{%"name%":%"Test collection%",%"books%":[{%"title%":%"eJSON: The Definitive Guide%",%"isbn%":%"123123-413243%",%"author%":{%"name%":%"Foo Bar%"}}]}"
 			create parser.make_parser (jrep)

--- a/test/autotest/test_suite/test_json_custom_classes.e
+++ b/test/autotest/test_suite/test_json_custom_classes.e
@@ -35,7 +35,7 @@ feature -- Test
 			jrep := "{%"name%":%"Test collection%",%"books%":[{%"title%":%"eJSON: The Definitive Guide%",%"isbn%":%"123123-413243%",%"author%":{%"name%":%"Foo Bar%"}}]}"
 			create parser.make_parser (jrep)
 			if attached {JSON_OBJECT} parser.parse as l_json_object then
-				if attached {BOOK_COLLECTION} json.object (l_json_object, {BOOK_COLLECTION}) as l_collection then
+				if attached {BOOK_COLLECTION} json.instance (l_json_object, {BOOK_COLLECTION}) as l_collection then
 					if attached {JSON_OBJECT} json.value (l_collection) as l_json_object_2 then
 						assert ("JSON representation is correct", l_json_object_2.representation.same_string (jrep))
 					else

--- a/test/autotest/test_suite/test_json_suite.e
+++ b/test/autotest/test_suite/test_json_suite.e
@@ -491,7 +491,7 @@ feature -- JSON_FROM_FILE
 			test_dir: STRING
 			i: INTEGER
 		do
-			test_dir := (create {EXECUTION_ENVIRONMENT}).current_working_directory
+			test_dir := (create {EXECUTION_ENVIRONMENT}).current_working_path.out
 			test_dir.append_character ((create {OPERATING_ENVIRONMENT}).directory_separator)
 			l_path := test_dir + fn
 			create f.make_with_name (l_path)


### PR DESCRIPTION
## Overview
- Use instance of {TYPE} instead of labels to take advantage of static checking.
- Improve converter abstraction and implementations to reduce the developper work.
- Remove dangerous once routines.
- Prefer the use of converters instead of custom codes for JSON_OBJECT and JSON_ARRAY conversions.
- Replace custom creation procedures with default ones.
- Update style, documentation and loop construction.
## Next pull-requests:

This pull-request prepare the next.
A final goal is to allow to use Contextual typing (see https://docs.eiffel.com/sites/docs.eiffel.com/files/expression_language_0.pdf) when they will be available. i.e.
`object (a_json: JSON_VALUE; a_type: TYPE [?]): ?`
